### PR TITLE
> If you are using a strict package manager like pnpm, you may need t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "astro": "5.0.0-beta.1",
     "astro-icon": "^1.1.1",
     "marked": "^14.0.0",
+    "sharp": "^0.33.5",
     "tailwindcss": "^3.3.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       marked:
         specifier: ^14.0.0
         version: 14.0.0
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
       tailwindcss:
         specifier: ^3.3.2
         version: 3.4.10(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.5.4))
@@ -6291,13 +6294,11 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    optional: true
 
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    optional: true
 
   colorette@2.0.20: {}
 
@@ -6429,8 +6430,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.0.3:
-    optional: true
+  detect-libc@2.0.3: {}
 
   deterministic-object-hash@2.0.2:
     dependencies:
@@ -7047,8 +7047,7 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.2:
-    optional: true
+  is-arrayish@0.3.2: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -8261,7 +8260,6 @@ snapshots:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -8289,7 +8287,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-    optional: true
 
   sisteransi@1.0.5: {}
 


### PR DESCRIPTION
…o install the sharp package manually to use the Sharp image service, even though it is built into Astro by default.